### PR TITLE
remove deployment section from vault bip

### DIFF
--- a/bip-vaults.mediawiki
+++ b/bip-vaults.mediawiki
@@ -633,8 +633,7 @@ Script descriptors for vault-related outputs will be covered in a subsequent BIP
 
 == Deployment ==
 
-It is anticipated that deployment would happen in the same way [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#user-content-Deployment that BIP-0341 was deployed]. Parameters to be determined.
-
+To be determined.
 
 == Rationale ==
 


### PR DESCRIPTION
deployment methods are their own discussion. Suggest leaving this section TBD until there has been more discussion around the actual BIP. 